### PR TITLE
Add `podLables` to helm chart

### DIFF
--- a/charts/trivy-operator-polr-adapter/templates/deployment.yaml
+++ b/charts/trivy-operator-polr-adapter/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       {{- end }}
       labels:
         {{- include "trivy-operator-polr-adapter.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/trivy-operator-polr-adapter/values.yaml
+++ b/charts/trivy-operator-polr-adapter/values.yaml
@@ -67,6 +67,8 @@ rbac:
 
 podAnnotations: {}
 
+podLabels: {}
+
 securityContext:
   runAsUser: 1234
   runAsNonRoot: true


### PR DESCRIPTION
This PR adds `podLabels` to the helm chart to be able to add eg. owner or other custom labels to the pods.