### PR TITLE
fix: properly delete rbac and vulnr policy reports

### DIFF
--- a/pkg/adapters/rbac/client.go
+++ b/pkg/adapters/rbac/client.go
@@ -37,7 +37,7 @@ func (e *Client) StartWatching(ctx context.Context) error {
 			}
 		},
 		DeleteFunc: func(ctx context.Context, event event.TypedDeleteEvent[*v1alpha1.RbacAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			err := e.polrClient.GenerateReport(ctx, event.Object)
+			err := e.polrClient.DeleteReport(ctx, event.Object)
 			if err != nil {
 				log.Printf("[ERROR] RbacAssessmentReport: Failed to delete report %s; %s", event.Object.Name, err)
 			}

--- a/pkg/adapters/vulnr/client.go
+++ b/pkg/adapters/vulnr/client.go
@@ -37,7 +37,7 @@ func (e *Client) StartWatching(ctx context.Context) error {
 			}
 		},
 		DeleteFunc: func(ctx context.Context, event event.TypedDeleteEvent[*v1alpha1.VulnerabilityReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			err := e.polrClient.GenerateReport(ctx, event.Object)
+			err := e.polrClient.DeleteReport(ctx, event.Object)
 			if err != nil {
 				log.Printf("[ERROR] VulnerabilityReport: Failed to delete report %s; %s", event.Object.Name, err)
 			}


### PR DESCRIPTION
Call proper delete function on deletion to properly delete generated report