### PR TITLE
Remove `creationTimestamp` to conform with crds schema

### DIFF
--- a/charts/trivy-operator-polr-adapter/Chart.yaml
+++ b/charts/trivy-operator-polr-adapter/Chart.yaml
@@ -3,5 +3,5 @@ name: trivy-operator-polr-adapter
 description: Helm Chart to install the trivy-operator PolicyReport adapter
 
 type: application
-version: "0.10.1"
+version: "0.10.2"
 appVersion: "0.10.1"

--- a/charts/trivy-operator-polr-adapter/templates/wgpolicyk8s.io_clusterpolicyreports.yaml
+++ b/charts/trivy-operator-polr-adapter/templates/wgpolicyk8s.io_clusterpolicyreports.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: clusterpolicyreports.wgpolicyk8s.io
 spec:
   group: wgpolicyk8s.io

--- a/charts/trivy-operator-polr-adapter/templates/wgpolicyk8s.io_policyreports.yaml
+++ b/charts/trivy-operator-polr-adapter/templates/wgpolicyk8s.io_policyreports.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: policyreports.wgpolicyk8s.io
 spec:
   group: wgpolicyk8s.io


### PR DESCRIPTION
`CreationTimestamp` should not be set by the clients and it should be string. Some tools like `kubeconform`  will fail on schema validation as `CreationTimestamp` should be string and not null.