### PR TITLE
Report cleanup

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -30,7 +30,9 @@ func loadConfig(cmd *cobra.Command) (*config.Config, error) {
 	if flag := cmd.Flags().Lookup("kubeconfig"); flag != nil {
 		v.BindPFlag("kubeconfig", flag)
 	}
-
+	if flag := cmd.Flags().Lookup("verbosity"); flag != nil {
+		v.BindPFlag("logger.verbosity", flag)
+	}
 	if flag := cmd.Flags().Lookup("enable-vulnerability"); flag != nil {
 		v.BindPFlag("vulnerabilityReports.enabled", flag)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"flag"
-	"log"
 	"os"
 	"os/signal"
 	"time"
@@ -28,10 +27,12 @@ func newRunCMD() *cobra.Command {
 				return err
 			}
 
+			ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(c.Logger.Verbosity))))
+
 			if setter, ok := clientfeatures.FeatureGates().(interface {
 				Set(clientfeatures.Feature, bool) error
 			}); ok {
-				log.Printf("[INFO] WatchList client feature: %v\n", c.UseWatchList)
+				ctrl.Log.V(4).Info("WatchList client feature", "enabled", c.UseWatchList)
 				_ = setter.Set(clientfeatures.WatchListClient, c.UseWatchList)
 			}
 
@@ -41,8 +42,6 @@ func newRunCMD() *cobra.Command {
 			} else {
 				k8sConfig, err = rest.InClusterConfig()
 			}
-
-			ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(2))))
 
 			resolver := config.NewResolver(c, k8sConfig)
 
@@ -57,17 +56,23 @@ func newRunCMD() *cobra.Command {
 					break
 				}
 
-				log.Printf("[ERROR] %s\n", err)
+				ctrl.Log.Error(err, "CRD validation failed, retrying in 1 minute")
 				time.Sleep(time.Minute)
 			}
 
+			logger := ctrl.Log.V(2)
+
 			if c.ConfigAuditReports.Enabled {
-				log.Println("[INFO] ConfigAuditReports enabled")
+				logger.Info("ConfigAuditReports enabled")
 				auditrClient, err := resolver.ConfigAuditReportClient()
 				if err != nil {
 					return err
 				}
 
+				err = auditrClient.Cleanup(cmd.Context())
+				if err != nil {
+					return err
+				}
 				err = auditrClient.StartWatching()
 				if err != nil {
 					return err
@@ -75,8 +80,13 @@ func newRunCMD() *cobra.Command {
 			}
 
 			if c.VulnerabilityReports.Enabled {
-				log.Println("[INFO] VulnerabilityReports enabled")
+				logger.Info("VulnerabilityReports enabled")
 				vulnrClient, err := resolver.VulnerabilityReportClient()
+				if err != nil {
+					return err
+				}
+
+				err = vulnrClient.Cleanup(cmd.Context())
 				if err != nil {
 					return err
 				}
@@ -88,8 +98,13 @@ func newRunCMD() *cobra.Command {
 			}
 
 			if c.ClusterVulnerabilityReports.Enabled {
-				log.Println("[INFO] ClusterVulnerabilityReports enabled")
+				logger.Info("ClusterVulnerabilityReports enabled")
 				clustervulnrClient, err := resolver.ClusterVulnerabilityReportClient()
+				if err != nil {
+					return err
+				}
+
+				err = clustervulnrClient.Cleanup(cmd.Context())
 				if err != nil {
 					return err
 				}
@@ -101,8 +116,13 @@ func newRunCMD() *cobra.Command {
 			}
 
 			if c.ComplianceReports.Enabled {
-				log.Println("[INFO] ComplianceReports enabled")
+				logger.Info("ComplianceReports enabled")
 				complianceClient, err := resolver.ComplianceReportClient()
+				if err != nil {
+					return err
+				}
+
+				err = complianceClient.Cleanup(cmd.Context())
 				if err != nil {
 					return err
 				}
@@ -114,8 +134,13 @@ func newRunCMD() *cobra.Command {
 			}
 
 			if c.RbacAssessmentReports.Enabled {
-				log.Println("[INFO] RbacAssessmentReports enabled")
+				logger.Info("RbacAssessmentReports enabled")
 				rbacClient, err := resolver.RbacAssessmentReportClient()
+				if err != nil {
+					return err
+				}
+
+				err = rbacClient.Cleanup(cmd.Context())
 				if err != nil {
 					return err
 				}
@@ -130,6 +155,11 @@ func newRunCMD() *cobra.Command {
 					return err
 				}
 
+				err = clusterrbacClient.Cleanup(cmd.Context())
+				if err != nil {
+					return err
+				}
+
 				err = clusterrbacClient.StartWatching(cmd.Context())
 				if err != nil {
 					return err
@@ -137,8 +167,13 @@ func newRunCMD() *cobra.Command {
 			}
 
 			if c.ExposedSecretReports.Enabled {
-				log.Println("[INFO] ExposedSecretReports enabled")
+				logger.Info("ExposedSecretReports enabled")
 				secretClient, err := resolver.ExposedSecretReportClient()
+				if err != nil {
+					return err
+				}
+
+				err = secretClient.Cleanup(cmd.Context())
 				if err != nil {
 					return err
 				}
@@ -150,8 +185,13 @@ func newRunCMD() *cobra.Command {
 			}
 
 			if c.CISKubeBenchReports.Enabled {
-				log.Println("[INFO] CISKubeBenchReports enabled")
+				logger.Info("CISKubeBenchReports enabled")
 				kubeBenchClient, err := resolver.CISKubeBenchReportClient()
+				if err != nil {
+					return err
+				}
+
+				err = kubeBenchClient.Cleanup(cmd.Context())
 				if err != nil {
 					return err
 				}
@@ -163,8 +203,13 @@ func newRunCMD() *cobra.Command {
 			}
 
 			if c.InfraAssessmentReports.Enabled {
-				log.Println("[INFO] InfraAssessmentReportClient enabled")
+				logger.Info("InfraAssessmentReports enabled")
 				infraClient, err := resolver.InfraAssessmentReportClient()
+				if err != nil {
+					return err
+				}
+
+				err = infraClient.Cleanup(cmd.Context())
 				if err != nil {
 					return err
 				}
@@ -176,8 +221,13 @@ func newRunCMD() *cobra.Command {
 			}
 
 			if c.ClusterInfraAssessmentReports.Enabled {
-				log.Println("[INFO] ClusterInfraAssessmentReportClient enabled")
+				logger.Info("ClusterInfraAssessmentReports enabled")
 				clusterInfraClient, err := resolver.ClusterInfraAssessmentReportClient()
+				if err != nil {
+					return err
+				}
+
+				err = clusterInfraClient.Cleanup(cmd.Context())
 				if err != nil {
 					return err
 				}
@@ -204,6 +254,7 @@ func newRunCMD() *cobra.Command {
 	cmd.PersistentFlags().StringP("kubeconfig", "k", "", "absolute path to the kubeconfig file")
 	cmd.PersistentFlags().IntP("port", "p", 8080, "Port of the Server")
 	cmd.PersistentFlags().StringP("config", "c", "", "target configuration file")
+	cmd.PersistentFlags().IntP("verbosity", "v", 2, "Verbosity level of the logger")
 
 	cmd.PersistentFlags().Bool("enable-vulnerability", false, "Enable the transformation of VulnerabilityReports into PolicyReports")
 	cmd.PersistentFlags().Bool("enable-config-audit", false, "Enable the transformation of ConfigAuditReports into PolicyReports")

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/fjogeleit/trivy-operator-polr-adapter
 go 1.26.4
 
 require (
+	github.com/go-logr/logr v1.4.3
 	github.com/openreports/reports-api v0.2.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
@@ -23,7 +24,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.24.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.6 // indirect
 	github.com/go-openapi/swag v0.27.0 // indirect

--- a/pkg/adapters/auditr/client.go
+++ b/pkg/adapters/auditr/client.go
@@ -44,6 +44,10 @@ func (e *Client) StartWatching() error {
 	}))
 }
 
+func (e *Client) Cleanup(ctx context.Context) error {
+	return e.client.Cleanup(ctx)
+}
+
 func NewClient(mgr manager.Manager, controller controller.Controller, orClient ReportClient) *Client {
 	return &Client{
 		manager:    mgr,

--- a/pkg/adapters/auditr/client.go
+++ b/pkg/adapters/auditr/client.go
@@ -2,12 +2,12 @@ package auditr
 
 import (
 	"context"
-	"log"
 
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -26,19 +26,19 @@ func (e *Client) StartWatching() error {
 		CreateFunc: func(ctx context.Context, event event.TypedCreateEvent[*v1alpha1.ConfigAuditReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] ConfigAuditReport: Failed to process report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "ConfigAuditReport: failed to process report", "report", event.Object.Name)
 			}
 		},
 		UpdateFunc: func(ctx context.Context, event event.TypedUpdateEvent[*v1alpha1.ConfigAuditReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.ObjectNew)
 			if err != nil {
-				log.Printf("[ERROR] ConfigAuditReport: Failed to process report %s; %s", event.ObjectNew.Name, err)
+				ctrl.Log.Error(err, "ConfigAuditReport: failed to process report", "report", event.ObjectNew.Name)
 			}
 		},
 		DeleteFunc: func(ctx context.Context, event event.TypedDeleteEvent[*v1alpha1.ConfigAuditReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.DeleteReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] ConfigAuditReport: Failed to delete report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "ConfigAuditReport: failed to delete report", "report", event.Object.Name)
 			}
 		},
 	}))

--- a/pkg/adapters/auditr/openreports/client.go
+++ b/pkg/adapters/auditr/openreports/client.go
@@ -1,10 +1,10 @@
 package openreports
 
 import (
+	"context"
 	"fmt"
 
 	or "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -56,6 +56,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Config
 
 		return nil
 	})
+}
+
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.OpenReportCleanup(ctx, p.k8sClient, "ConfigAuditReport")
 }
 
 func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []string) auditr.ReportClient {

--- a/pkg/adapters/auditr/openreports/client.go
+++ b/pkg/adapters/auditr/openreports/client.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	or "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/auditr"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
@@ -17,6 +19,7 @@ import (
 type reportClient struct {
 	k8sClient or.OpenreportsV1alpha1Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.ConfigAuditReport) error {
@@ -32,10 +35,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Conf
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting Report", "report", report.Name, "namespace", report.Namespace)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating Report", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.Reports(report.Namespace).Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating Report", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.Reports(report.Namespace).Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -66,5 +72,6 @@ func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []strin
 	return &reportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("ConfigAuditReportOpenReportsClient").V(4),
 	}
 }

--- a/pkg/adapters/auditr/polr_client.go
+++ b/pkg/adapters/auditr/polr_client.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/apis/aquasecurity/v1alpha1"
@@ -22,6 +24,7 @@ type ReportClient interface {
 type reportClient struct {
 	k8sClient pr.Wgpolicyk8sV1alpha2Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.ConfigAuditReport) error {
@@ -37,10 +40,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Conf
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.PolicyReports(report.Namespace).Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.PolicyReports(report.Namespace).Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -71,5 +77,6 @@ func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []strin
 	return &reportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("ConfigAuditReportClient").V(4),
 	}
 }

--- a/pkg/adapters/auditr/polr_client.go
+++ b/pkg/adapters/auditr/polr_client.go
@@ -1,9 +1,9 @@
 package auditr
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -16,6 +16,7 @@ import (
 type ReportClient interface {
 	GenerateReport(ctx context.Context, report *v1alpha1.ConfigAuditReport) error
 	DeleteReport(ctx context.Context, report *v1alpha1.ConfigAuditReport) error
+	Cleanup(ctx context.Context) error
 }
 
 type reportClient struct {
@@ -60,6 +61,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Config
 
 		return nil
 	})
+}
+
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.WGPolrCleanup(ctx, p.k8sClient, "ConfigAuditReport")
 }
 
 func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []string) ReportClient {

--- a/pkg/adapters/clusterinfra/client.go
+++ b/pkg/adapters/clusterinfra/client.go
@@ -2,12 +2,12 @@ package clusterinfra
 
 import (
 	"context"
-	"log"
 
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -26,19 +26,19 @@ func (e *Client) StartWatching(ctx context.Context) error {
 		CreateFunc: func(ctx context.Context, event event.TypedCreateEvent[*v1alpha1.ClusterInfraAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] ClusterInfraAssessmentReport: Failed to process report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "ClusterInfraAssessmentReport: failed to process report", "report", event.Object.Name)
 			}
 		},
 		UpdateFunc: func(ctx context.Context, event event.TypedUpdateEvent[*v1alpha1.ClusterInfraAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.ObjectNew)
 			if err != nil {
-				log.Printf("[ERROR] ClusterInfraAssessmentReport: Failed to process report %s; %s", event.ObjectNew.Name, err)
+				ctrl.Log.Error(err, "ClusterInfraAssessmentReport: failed to process report", "report", event.ObjectNew.Name)
 			}
 		},
 		DeleteFunc: func(ctx context.Context, event event.TypedDeleteEvent[*v1alpha1.ClusterInfraAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.DeleteReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] ClusterInfraAssessmentReport: Failed to delete report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "ClusterInfraAssessmentReport: failed to delete report", "report", event.Object.Name)
 			}
 		},
 	}))

--- a/pkg/adapters/clusterinfra/client.go
+++ b/pkg/adapters/clusterinfra/client.go
@@ -44,6 +44,10 @@ func (e *Client) StartWatching(ctx context.Context) error {
 	}))
 }
 
+func (e *Client) Cleanup(ctx context.Context) error {
+	return e.client.Cleanup(ctx)
+}
+
 func NewClient(mgr manager.Manager, controller controller.Controller, rclient ReportClient) *Client {
 	return &Client{
 		manager:    mgr,

--- a/pkg/adapters/clusterinfra/openreports/client.go
+++ b/pkg/adapters/clusterinfra/openreports/client.go
@@ -1,13 +1,15 @@
 package clusterinfra
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	or "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/clusterinfra"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
@@ -17,6 +19,7 @@ import (
 type reportClient struct {
 	k8sClient or.OpenreportsV1alpha1Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.ClusterInfraAssessmentReport) error {
@@ -32,10 +35,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Clus
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting ClusterReport", "report", report.Name)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating ClusterReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterReports().Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating ClusterReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterReports().Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -75,5 +81,6 @@ func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []strin
 	return &reportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("ClusterInfraAssessmentReportOpenReportsClient").V(4),
 	}
 }

--- a/pkg/adapters/clusterinfra/openreports/client.go
+++ b/pkg/adapters/clusterinfra/openreports/client.go
@@ -58,6 +58,19 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Cluste
 	})
 }
 
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := p.k8sClient.ClusterReports().DeleteCollection(ctx, v1.DeleteOptions{}, v1.ListOptions{
+			LabelSelector: "trivy-operator.source=ClusterInfraAssessmentReport",
+		})
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+
+		return nil
+	})
+}
+
 func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []string) clusterinfra.ReportClient {
 	return &reportClient{
 		k8sClient: client,

--- a/pkg/adapters/clusterinfra/polr_client.go
+++ b/pkg/adapters/clusterinfra/polr_client.go
@@ -1,12 +1,14 @@
 package clusterinfra
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/apis/aquasecurity/v1alpha1"
@@ -22,6 +24,7 @@ type ReportClient interface {
 type reportClient struct {
 	k8sClient pr.Wgpolicyk8sV1alpha2Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.ClusterInfraAssessmentReport) error {
@@ -37,10 +40,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Clus
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting ClusterPolicyReport", "report", report.Name)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating ClusterPolicyReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterPolicyReports().Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating ClusterPolicyReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterPolicyReports().Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -71,5 +77,6 @@ func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []strin
 	return &reportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("ClusterInfraAssessmentReportClient").V(4),
 	}
 }

--- a/pkg/adapters/clusterinfra/polr_client.go
+++ b/pkg/adapters/clusterinfra/polr_client.go
@@ -16,6 +16,7 @@ import (
 type ReportClient interface {
 	GenerateReport(ctx context.Context, report *v1alpha1.ClusterInfraAssessmentReport) error
 	DeleteReport(ctx context.Context, report *v1alpha1.ClusterInfraAssessmentReport) error
+	Cleanup(ctx context.Context) error
 }
 
 type reportClient struct {
@@ -60,6 +61,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Cluste
 
 		return nil
 	})
+}
+
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.WGPolrCleanup(ctx, p.k8sClient, "ClusterInfraAssessmentReport")
 }
 
 func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []string) ReportClient {

--- a/pkg/adapters/clusterrbac/client.go
+++ b/pkg/adapters/clusterrbac/client.go
@@ -2,12 +2,12 @@ package clusterrbac
 
 import (
 	"context"
-	"log"
 
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -26,19 +26,19 @@ func (e *Client) StartWatching(ctx context.Context) error {
 		CreateFunc: func(ctx context.Context, event event.TypedCreateEvent[*v1alpha1.ClusterRbacAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] ClusterRbacAssessmentReport: Failed to process report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "ClusterRbacAssessmentReport: failed to process report", "report", event.Object.Name)
 			}
 		},
 		UpdateFunc: func(ctx context.Context, event event.TypedUpdateEvent[*v1alpha1.ClusterRbacAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.ObjectNew)
 			if err != nil {
-				log.Printf("[ERROR] ClusterRbacAssessmentReport: Failed to process report %s; %s", event.ObjectNew.Name, err)
+				ctrl.Log.Error(err, "ClusterRbacAssessmentReport: failed to process report", "report", event.ObjectNew.Name)
 			}
 		},
 		DeleteFunc: func(ctx context.Context, event event.TypedDeleteEvent[*v1alpha1.ClusterRbacAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.DeleteReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] ClusterRbacAssessmentReport: Failed to delete report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "ClusterRbacAssessmentReport: failed to delete report", "report", event.Object.Name)
 			}
 		},
 	}))

--- a/pkg/adapters/clusterrbac/client.go
+++ b/pkg/adapters/clusterrbac/client.go
@@ -44,6 +44,10 @@ func (e *Client) StartWatching(ctx context.Context) error {
 	}))
 }
 
+func (e *Client) Cleanup(ctx context.Context) error {
+	return e.client.Cleanup(ctx)
+}
+
 func NewClient(mgr manager.Manager, controller controller.Controller, rclient ReportClient) *Client {
 	return &Client{
 		manager:    mgr,

--- a/pkg/adapters/clusterrbac/openreports/client.go
+++ b/pkg/adapters/clusterrbac/openreports/client.go
@@ -1,13 +1,15 @@
 package openreports
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	or "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/clusterrbac"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
@@ -17,6 +19,7 @@ import (
 type PolicyReportClient struct {
 	k8sClient or.OpenreportsV1alpha1Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *PolicyReportClient) GenerateReport(ctx context.Context, report *v1alpha1.ClusterRbacAssessmentReport) error {
@@ -32,10 +35,13 @@ func (p *PolicyReportClient) GenerateReport(ctx context.Context, report *v1alpha
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting ClusterReport", "report", report.Name)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating ClusterReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterReports().Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating ClusterReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterReports().Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -66,5 +72,6 @@ func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []strin
 	return &PolicyReportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("ClusterRbacAssessmentReportOpenReportsClient").V(4),
 	}
 }

--- a/pkg/adapters/clusterrbac/openreports/client.go
+++ b/pkg/adapters/clusterrbac/openreports/client.go
@@ -58,6 +58,10 @@ func (p *PolicyReportClient) DeleteReport(ctx context.Context, report *v1alpha1.
 	})
 }
 
+func (p *PolicyReportClient) Cleanup(ctx context.Context) error {
+	return shared.OpenReportCleanup(ctx, p.k8sClient, "ClusterRbacAssessmentReport")
+}
+
 func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []string) *PolicyReportClient {
 	return &PolicyReportClient{
 		k8sClient: client,

--- a/pkg/adapters/clusterrbac/polr_client.go
+++ b/pkg/adapters/clusterrbac/polr_client.go
@@ -1,12 +1,14 @@
 package clusterrbac
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/apis/aquasecurity/v1alpha1"
@@ -22,6 +24,7 @@ type ReportClient interface {
 type reportClient struct {
 	k8sClient pr.Wgpolicyk8sV1alpha2Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.ClusterRbacAssessmentReport) error {
@@ -37,15 +40,18 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Clus
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting ClusterPolicyReport", "report", report.Name)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating ClusterPolicyReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterPolicyReports().Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating ClusterPolicyReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterPolicyReports().Create(ctx, polr, v1.CreateOptions{})
 		}
 
 		if err != nil {
-			return fmt.Errorf("failed to create ClusterPolicyReport %s: %w", report.Name, err)
+			return fmt.Errorf("failed to create or update ClusterPolicyReport %s: %w", report.Name, err)
 		}
 
 		return nil
@@ -71,5 +77,6 @@ func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []strin
 	return &reportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("ClusterRbacAssessmentReportClient").V(4),
 	}
 }

--- a/pkg/adapters/clusterrbac/polr_client.go
+++ b/pkg/adapters/clusterrbac/polr_client.go
@@ -16,6 +16,7 @@ import (
 type ReportClient interface {
 	GenerateReport(ctx context.Context, report *v1alpha1.ClusterRbacAssessmentReport) error
 	DeleteReport(ctx context.Context, report *v1alpha1.ClusterRbacAssessmentReport) error
+	Cleanup(ctx context.Context) error
 }
 
 type reportClient struct {
@@ -60,6 +61,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Cluste
 
 		return nil
 	})
+}
+
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.WGPolrCleanup(ctx, p.k8sClient, "ClusterRbacAssessmentReport")
 }
 
 func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []string) ReportClient {

--- a/pkg/adapters/clustervulnr/client.go
+++ b/pkg/adapters/clustervulnr/client.go
@@ -17,6 +17,7 @@ import (
 
 type Client interface {
 	StartWatching(ctx context.Context) error
+	Cleanup(ctx context.Context) error
 }
 
 type client struct {
@@ -46,6 +47,10 @@ func (e *client) StartWatching(ctx context.Context) error {
 			}
 		},
 	}))
+}
+
+func (e *client) Cleanup(ctx context.Context) error {
+	return e.client.Cleanup(ctx)
 }
 
 func NewClient(mgr manager.Manager, controller controller.Controller, orClient ReportClient) Client {

--- a/pkg/adapters/clustervulnr/client.go
+++ b/pkg/adapters/clustervulnr/client.go
@@ -2,12 +2,12 @@ package clustervulnr
 
 import (
 	"context"
-	"log"
 
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -31,19 +31,19 @@ func (e *client) StartWatching(ctx context.Context) error {
 		CreateFunc: func(ctx context.Context, event event.TypedCreateEvent[*v1alpha1.ClusterVulnerabilityReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] ClusterVulnerabilityReport: Failed to process report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "ClusterVulnerabilityReport: failed to process report", "report", event.Object.Name)
 			}
 		},
 		UpdateFunc: func(ctx context.Context, event event.TypedUpdateEvent[*v1alpha1.ClusterVulnerabilityReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.ObjectNew)
 			if err != nil {
-				log.Printf("[ERROR] ClusterVulnerabilityReport: Failed to process report %s; %s", event.ObjectNew.Name, err)
+				ctrl.Log.Error(err, "ClusterVulnerabilityReport: failed to process report", "report", event.ObjectNew.Name)
 			}
 		},
 		DeleteFunc: func(ctx context.Context, event event.TypedDeleteEvent[*v1alpha1.ClusterVulnerabilityReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.DeleteReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] ClusterVulnerabilityReport: Failed to delete report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "ClusterVulnerabilityReport: failed to delete report", "report", event.Object.Name)
 			}
 		},
 	}))

--- a/pkg/adapters/clustervulnr/openreports/or_client.go
+++ b/pkg/adapters/clustervulnr/openreports/or_client.go
@@ -58,6 +58,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Cluste
 	})
 }
 
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.OpenReportCleanup(ctx, p.k8sClient, "ClusterVulnerabilityReport")
+}
+
 func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []string) clustervulnr.ReportClient {
 	return &reportClient{
 		k8sClient: client,

--- a/pkg/adapters/clustervulnr/openreports/or_client.go
+++ b/pkg/adapters/clustervulnr/openreports/or_client.go
@@ -1,13 +1,15 @@
 package openreports
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	or "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/clustervulnr"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
@@ -17,6 +19,7 @@ import (
 type reportClient struct {
 	k8sClient or.OpenreportsV1alpha1Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.ClusterVulnerabilityReport) error {
@@ -32,10 +35,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Clus
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting ClusterReport", "report", report.Name)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating ClusterReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterReports().Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating ClusterReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterReports().Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -68,5 +74,6 @@ func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []strin
 		mapper: &mapper{
 			LabelMapper: shared.NewLabelMapper(applyLabels),
 		},
+		logger:    ctrl.Log.WithName("ClusterVulnerabilityReportOpenReportsClient").V(4),
 	}
 }

--- a/pkg/adapters/clustervulnr/polr_client.go
+++ b/pkg/adapters/clustervulnr/polr_client.go
@@ -1,12 +1,14 @@
 package clustervulnr
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/apis/aquasecurity/v1alpha1"
@@ -22,6 +24,7 @@ type ReportClient interface {
 type reportClient struct {
 	k8sClient pr.Wgpolicyk8sV1alpha2Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.ClusterVulnerabilityReport) error {
@@ -37,10 +40,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Clus
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting ClusterPolicyReport", "report", report.Name)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating ClusterPolicyReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterPolicyReports().Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating ClusterPolicyReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterPolicyReports().Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -73,5 +79,6 @@ func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []strin
 		mapper: &mapper{
 			LabelMapper: shared.NewLabelMapper(applyLabels),
 		},
+		logger: ctrl.Log.WithName("ClusterVulnerabilityReportClient").V(4),
 	}
 }

--- a/pkg/adapters/clustervulnr/polr_client.go
+++ b/pkg/adapters/clustervulnr/polr_client.go
@@ -16,6 +16,7 @@ import (
 type ReportClient interface {
 	GenerateReport(ctx context.Context, report *v1alpha1.ClusterVulnerabilityReport) error
 	DeleteReport(ctx context.Context, report *v1alpha1.ClusterVulnerabilityReport) error
+	Cleanup(ctx context.Context) error
 }
 
 type reportClient struct {
@@ -60,6 +61,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Cluste
 
 		return nil
 	})
+}
+
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.WGPolrCleanup(ctx, p.k8sClient, "ClusterVulnerabilityReport")
 }
 
 func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []string) ReportClient {

--- a/pkg/adapters/compliance/client.go
+++ b/pkg/adapters/compliance/client.go
@@ -2,12 +2,12 @@ package compliance
 
 import (
 	"context"
-	"log"
 
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -26,19 +26,19 @@ func (e *Client) StartWatching(ctx context.Context) error {
 		CreateFunc: func(ctx context.Context, event event.TypedCreateEvent[*v1alpha1.ClusterComplianceReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] ClusterComplianceDetailReport: Failed to process report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "ClusterComplianceDetailReport: failed to process report", "report", event.Object.Name)
 			}
 		},
 		UpdateFunc: func(ctx context.Context, event event.TypedUpdateEvent[*v1alpha1.ClusterComplianceReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.ObjectNew)
 			if err != nil {
-				log.Printf("[ERROR] ClusterComplianceDetailReport: Failed to process report %s; %s", event.ObjectNew.Name, err)
+				ctrl.Log.Error(err, "ClusterComplianceDetailReport: failed to process report", "report", event.ObjectNew.Name)
 			}
 		},
 		DeleteFunc: func(ctx context.Context, event event.TypedDeleteEvent[*v1alpha1.ClusterComplianceReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.DeleteReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] ClusterComplianceDetailReport: Failed to delete report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "ClusterComplianceDetailReport: failed to delete report", "report", event.Object.Name)
 			}
 		},
 	}))

--- a/pkg/adapters/compliance/client.go
+++ b/pkg/adapters/compliance/client.go
@@ -44,6 +44,10 @@ func (e *Client) StartWatching(ctx context.Context) error {
 	}))
 }
 
+func (e *Client) Cleanup(ctx context.Context) error {
+	return e.client.Cleanup(ctx)
+}
+
 func NewClient(mgr manager.Manager, controller controller.Controller, rclient ReportClient) *Client {
 	return &Client{
 		manager:    mgr,

--- a/pkg/adapters/compliance/openreports/client.go
+++ b/pkg/adapters/compliance/openreports/client.go
@@ -1,13 +1,15 @@
 package openreports
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	or "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/compliance"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
@@ -17,6 +19,7 @@ import (
 type reportClient struct {
 	k8sClient or.OpenreportsV1alpha1Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.ClusterComplianceReport) error {
@@ -32,10 +35,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Clus
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting ClusterReport", "report", report.Name)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating ClusterReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterReports().Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating ClusterReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterReports().Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -66,5 +72,6 @@ func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []strin
 	return &reportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("ClusterComplianceReportOpenReportsClient").V(4),
 	}
 }

--- a/pkg/adapters/compliance/openreports/client.go
+++ b/pkg/adapters/compliance/openreports/client.go
@@ -58,6 +58,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Cluste
 	})
 }
 
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.OpenReportCleanup(ctx, p.k8sClient, "ClusterComplianceReport")
+}
+
 func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []string) compliance.ReportClient {
 	return &reportClient{
 		k8sClient: client,

--- a/pkg/adapters/compliance/polr_client.go
+++ b/pkg/adapters/compliance/polr_client.go
@@ -1,12 +1,14 @@
 package compliance
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/apis/aquasecurity/v1alpha1"
@@ -22,6 +24,7 @@ type ReportClient interface {
 type reportClient struct {
 	k8sClient pr.Wgpolicyk8sV1alpha2Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.ClusterComplianceReport) error {
@@ -37,10 +40,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Clus
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting ClusterPolicyReport", "report", report.Name)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating ClusterPolicyReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterPolicyReports().Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating ClusterPolicyReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterPolicyReports().Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -71,5 +77,6 @@ func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []strin
 	return &reportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("ClusterComplianceReportClient").V(4),
 	}
 }

--- a/pkg/adapters/compliance/polr_client.go
+++ b/pkg/adapters/compliance/polr_client.go
@@ -16,6 +16,7 @@ import (
 type ReportClient interface {
 	GenerateReport(ctx context.Context, report *v1alpha1.ClusterComplianceReport) error
 	DeleteReport(ctx context.Context, report *v1alpha1.ClusterComplianceReport) error
+	Cleanup(ctx context.Context) error
 }
 
 type reportClient struct {
@@ -60,6 +61,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Cluste
 
 		return nil
 	})
+}
+
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.WGPolrCleanup(ctx, p.k8sClient, "ClusterComplianceReport")
 }
 
 func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []string) ReportClient {

--- a/pkg/adapters/exposedsecret/client.go
+++ b/pkg/adapters/exposedsecret/client.go
@@ -44,6 +44,10 @@ func (e *Client) StartWatching(ctx context.Context) error {
 	}))
 }
 
+func (e *Client) Cleanup(ctx context.Context) error {
+	return e.client.Cleanup(ctx)
+}
+
 func NewClient(mgr manager.Manager, client controller.Controller, rclient ReportClient) *Client {
 	return &Client{
 		manager:    mgr,

--- a/pkg/adapters/exposedsecret/client.go
+++ b/pkg/adapters/exposedsecret/client.go
@@ -2,12 +2,12 @@ package exposedsecret
 
 import (
 	"context"
-	"log"
 
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -26,19 +26,19 @@ func (e *Client) StartWatching(ctx context.Context) error {
 		CreateFunc: func(ctx context.Context, event event.TypedCreateEvent[*v1alpha1.ExposedSecretReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] ExposedSecretReport: Failed to process report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "ExposedSecretReport: failed to process report", "report", event.Object.Name)
 			}
 		},
 		UpdateFunc: func(ctx context.Context, event event.TypedUpdateEvent[*v1alpha1.ExposedSecretReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.ObjectNew)
 			if err != nil {
-				log.Printf("[ERROR] ExposedSecretReport: Failed to process report %s; %s", event.ObjectNew.Name, err)
+				ctrl.Log.Error(err, "ExposedSecretReport: failed to process report", "report", event.ObjectNew.Name)
 			}
 		},
 		DeleteFunc: func(ctx context.Context, event event.TypedDeleteEvent[*v1alpha1.ExposedSecretReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.DeleteReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] ExposedSecretReport: Failed to delete report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "ExposedSecretReport: failed to delete report", "report", event.Object.Name)
 			}
 		},
 	}))

--- a/pkg/adapters/exposedsecret/openreports/client.go
+++ b/pkg/adapters/exposedsecret/openreports/client.go
@@ -58,6 +58,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Expose
 	})
 }
 
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.OpenReportCleanup(ctx, p.k8sClient, "ExposedSecretReport")
+}
+
 func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []string) *reportClient {
 	return &reportClient{
 		k8sClient: client,

--- a/pkg/adapters/exposedsecret/openreports/client.go
+++ b/pkg/adapters/exposedsecret/openreports/client.go
@@ -1,13 +1,15 @@
 package openreports
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	or "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/exposedsecret"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
@@ -17,6 +19,7 @@ import (
 type reportClient struct {
 	k8sClient or.OpenreportsV1alpha1Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.ExposedSecretReport) error {
@@ -32,10 +35,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Expo
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting Report", "report", report.Name, "namespace", report.Namespace)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating Report", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.Reports(report.Namespace).Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating Report", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.Reports(report.Namespace).Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -66,5 +72,6 @@ func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []strin
 	return &reportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("ExposedSecretReportOpenReportsClient").V(4),
 	}
 }

--- a/pkg/adapters/exposedsecret/polr_client.go
+++ b/pkg/adapters/exposedsecret/polr_client.go
@@ -1,12 +1,14 @@
 package exposedsecret
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/apis/aquasecurity/v1alpha1"
@@ -22,6 +24,7 @@ type ReportClient interface {
 type reportClient struct {
 	k8sClient pr.Wgpolicyk8sV1alpha2Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.ExposedSecretReport) error {
@@ -37,10 +40,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Expo
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.PolicyReports(report.Namespace).Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.PolicyReports(report.Namespace).Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -71,5 +77,6 @@ func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []strin
 	return &reportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("ExposedSecretReportClient").V(4),
 	}
 }

--- a/pkg/adapters/exposedsecret/polr_client.go
+++ b/pkg/adapters/exposedsecret/polr_client.go
@@ -16,6 +16,7 @@ import (
 type ReportClient interface {
 	GenerateReport(ctx context.Context, report *v1alpha1.ExposedSecretReport) error
 	DeleteReport(ctx context.Context, report *v1alpha1.ExposedSecretReport) error
+	Cleanup(ctx context.Context) error
 }
 
 type reportClient struct {
@@ -60,6 +61,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Expose
 
 		return nil
 	})
+}
+
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.WGPolrCleanup(ctx, p.k8sClient, "ExposedSecretReport")
 }
 
 func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []string) ReportClient {

--- a/pkg/adapters/infra/client.go
+++ b/pkg/adapters/infra/client.go
@@ -2,12 +2,12 @@ package infra
 
 import (
 	"context"
-	"log"
 
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -26,19 +26,19 @@ func (e *Client) StartWatching(ctx context.Context) error {
 		CreateFunc: func(ctx context.Context, event event.TypedCreateEvent[*v1alpha1.InfraAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.polrClient.GenerateReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] InfraAssessmentReport: Failed to process report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "InfraAssessmentReport: failed to process report", "report", event.Object.Name)
 			}
 		},
 		UpdateFunc: func(ctx context.Context, event event.TypedUpdateEvent[*v1alpha1.InfraAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.polrClient.GenerateReport(ctx, event.ObjectNew)
 			if err != nil {
-				log.Printf("[ERROR] InfraAssessmentReport: Failed to process report %s; %s", event.ObjectNew.Name, err)
+				ctrl.Log.Error(err, "InfraAssessmentReport: failed to process report", "report", event.ObjectNew.Name)
 			}
 		},
 		DeleteFunc: func(ctx context.Context, event event.TypedDeleteEvent[*v1alpha1.InfraAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.polrClient.DeleteReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] InfraAssessmentReport: Failed to delete report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "InfraAssessmentReport: failed to delete report", "report", event.Object.Name)
 			}
 		},
 	}))

--- a/pkg/adapters/infra/client.go
+++ b/pkg/adapters/infra/client.go
@@ -44,6 +44,10 @@ func (e *Client) StartWatching(ctx context.Context) error {
 	}))
 }
 
+func (e *Client) Cleanup(ctx context.Context) error {
+	return e.polrClient.Cleanup(ctx)
+}
+
 func NewClient(mgr manager.Manager, controller controller.Controller, rclient ReportClient) *Client {
 	return &Client{
 		manager:    mgr,

--- a/pkg/adapters/infra/openreports/client.go
+++ b/pkg/adapters/infra/openreports/client.go
@@ -1,13 +1,15 @@
 package openreports
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	or "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/infra"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
@@ -17,6 +19,7 @@ import (
 type reportClient struct {
 	k8sClient or.OpenreportsV1alpha1Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.InfraAssessmentReport) error {
@@ -32,10 +35,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Infr
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting Report", "report", report.Name, "namespace", report.Namespace)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating Report", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.Reports(report.Namespace).Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating Report", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.Reports(report.Namespace).Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -66,5 +72,6 @@ func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []strin
 	return &reportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("InfraAssessmentReportOpenReportsClient").V(4),
 	}
 }

--- a/pkg/adapters/infra/openreports/client.go
+++ b/pkg/adapters/infra/openreports/client.go
@@ -58,6 +58,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.InfraA
 	})
 }
 
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.OpenReportCleanup(ctx, p.k8sClient, "InfraAssessmentReport")
+}
+
 func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []string) infra.ReportClient {
 	return &reportClient{
 		k8sClient: client,

--- a/pkg/adapters/infra/polr_client.go
+++ b/pkg/adapters/infra/polr_client.go
@@ -16,6 +16,7 @@ import (
 type ReportClient interface {
 	GenerateReport(ctx context.Context, report *v1alpha1.InfraAssessmentReport) error
 	DeleteReport(ctx context.Context, report *v1alpha1.InfraAssessmentReport) error
+	Cleanup(ctx context.Context) error
 }
 
 type reportClient struct {
@@ -60,6 +61,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.InfraA
 
 		return nil
 	})
+}
+
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.WGPolrCleanup(ctx, p.k8sClient, "InfraAssessmentReport")
 }
 
 func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []string) ReportClient {

--- a/pkg/adapters/infra/polr_client.go
+++ b/pkg/adapters/infra/polr_client.go
@@ -1,12 +1,14 @@
 package infra
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/apis/aquasecurity/v1alpha1"
@@ -22,6 +24,7 @@ type ReportClient interface {
 type reportClient struct {
 	k8sClient pr.Wgpolicyk8sV1alpha2Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.InfraAssessmentReport) error {
@@ -37,10 +40,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Infr
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.PolicyReports(report.Namespace).Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.PolicyReports(report.Namespace).Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -71,5 +77,6 @@ func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []strin
 	return &reportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("InfraAssessmentReportClient").V(4),
 	}
 }

--- a/pkg/adapters/kubebench/client.go
+++ b/pkg/adapters/kubebench/client.go
@@ -2,12 +2,12 @@ package kubebench
 
 import (
 	"context"
-	"log"
 
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -27,19 +27,19 @@ func (e *Client) StartWatching(ctx context.Context) error {
 		CreateFunc: func(ctx context.Context, event event.TypedCreateEvent[*v1alpha1.CISKubeBenchReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.polrClient.GenerateReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] CISKubeBenchReport: Failed to process report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "CISKubeBenchReport: failed to process report", "report", event.Object.Name)
 			}
 		},
 		UpdateFunc: func(ctx context.Context, event event.TypedUpdateEvent[*v1alpha1.CISKubeBenchReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.polrClient.GenerateReport(ctx, event.ObjectNew)
 			if err != nil {
-				log.Printf("[ERROR] CISKubeBenchReport: Failed to process report %s; %s", event.ObjectNew.Name, err)
+				ctrl.Log.Error(err, "CISKubeBenchReport: failed to process report", "report", event.ObjectNew.Name)
 			}
 		},
 		DeleteFunc: func(ctx context.Context, event event.TypedDeleteEvent[*v1alpha1.CISKubeBenchReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.polrClient.DeleteReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] CISKubeBenchReport: Failed to delete report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "CISKubeBenchReport: failed to delete report", "report", event.Object.Name)
 			}
 		},
 	}))

--- a/pkg/adapters/kubebench/client.go
+++ b/pkg/adapters/kubebench/client.go
@@ -45,6 +45,10 @@ func (e *Client) StartWatching(ctx context.Context) error {
 	}))
 }
 
+func (e *Client) Cleanup(ctx context.Context) error {
+	return e.polrClient.Cleanup(ctx)
+}
+
 func NewClient(mgr manager.Manager, client controller.Controller, polrClient v1alpha2.Wgpolicyk8sV1alpha2Interface, applyLabels []string) *Client {
 	return &Client{
 		manager:    mgr,

--- a/pkg/adapters/kubebench/polr_client.go
+++ b/pkg/adapters/kubebench/polr_client.go
@@ -1,12 +1,14 @@
 package kubebench
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/apis/aquasecurity/v1alpha1"
@@ -16,6 +18,7 @@ import (
 type PolicyReportClient struct {
 	k8sClient pr.Wgpolicyk8sV1alpha2Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *PolicyReportClient) GenerateReport(ctx context.Context, report *v1alpha1.CISKubeBenchReport) error {
@@ -31,8 +34,10 @@ func (p *PolicyReportClient) GenerateReport(ctx context.Context, report *v1alpha
 		if polr == nil {
 			return nil
 		} else if updated {
+			p.logger.Info("Updating ClusterPolicyReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterPolicyReports().Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating ClusterPolicyReport", "report", report.Name)
 			_, err = p.k8sClient.ClusterPolicyReports().Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -63,5 +68,6 @@ func NewPolicyReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels [
 	return &PolicyReportClient{
 		k8sClient: client,
 		mapper:    &mapper{shared.NewLabelMapper(applyLabels)},
+		logger:    ctrl.Log.WithName("CISKubeBenchReportClient").V(4),
 	}
 }

--- a/pkg/adapters/kubebench/polr_client.go
+++ b/pkg/adapters/kubebench/polr_client.go
@@ -55,6 +55,10 @@ func (p *PolicyReportClient) DeleteReport(ctx context.Context, report *v1alpha1.
 	})
 }
 
+func (p *PolicyReportClient) Cleanup(ctx context.Context) error {
+	return shared.WGPolrCleanup(ctx, p.k8sClient, "CISKubeBenchReport")
+}
+
 func NewPolicyReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []string) *PolicyReportClient {
 	return &PolicyReportClient{
 		k8sClient: client,

--- a/pkg/adapters/rbac/client.go
+++ b/pkg/adapters/rbac/client.go
@@ -44,6 +44,10 @@ func (e *Client) StartWatching(ctx context.Context) error {
 	}))
 }
 
+func (e *Client) Cleanup(ctx context.Context) error {
+	return e.client.Cleanup(ctx)
+}
+
 func NewClient(mgr manager.Manager, client controller.Controller, rclient ReportClient) *Client {
 	return &Client{
 		manager:    mgr,

--- a/pkg/adapters/rbac/client.go
+++ b/pkg/adapters/rbac/client.go
@@ -2,12 +2,12 @@ package rbac
 
 import (
 	"context"
-	"log"
 
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -26,19 +26,19 @@ func (e *Client) StartWatching(ctx context.Context) error {
 		CreateFunc: func(ctx context.Context, event event.TypedCreateEvent[*v1alpha1.RbacAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] RbacAssessmentReport: Failed to process report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "RbacAssessmentReport: failed to process report", "report", event.Object.Name)
 			}
 		},
 		UpdateFunc: func(ctx context.Context, event event.TypedUpdateEvent[*v1alpha1.RbacAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.GenerateReport(ctx, event.ObjectNew)
 			if err != nil {
-				log.Printf("[ERROR] RbacAssessmentReport: Failed to process report %s; %s", event.ObjectNew.Name, err)
+				ctrl.Log.Error(err, "RbacAssessmentReport: failed to process report", "report", event.ObjectNew.Name)
 			}
 		},
 		DeleteFunc: func(ctx context.Context, event event.TypedDeleteEvent[*v1alpha1.RbacAssessmentReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.client.DeleteReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] RbacAssessmentReport: Failed to delete report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "RbacAssessmentReport: failed to delete report", "report", event.Object.Name)
 			}
 		},
 	}))

--- a/pkg/adapters/rbac/openreports/client.go
+++ b/pkg/adapters/rbac/openreports/client.go
@@ -1,13 +1,15 @@
 package rbac
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	or "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/rbac"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
@@ -17,6 +19,7 @@ import (
 type reportClient struct {
 	k8sClient or.OpenreportsV1alpha1Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.RbacAssessmentReport) error {
@@ -32,10 +35,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Rbac
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting Report", "report", report.Name, "namespace", report.Namespace)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating Report", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.Reports(report.Namespace).Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating Report", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.Reports(report.Namespace).Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -68,5 +74,6 @@ func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []strin
 		mapper: &mapper{
 			shared.NewLabelMapper(applyLabels),
 		},
+		logger: ctrl.Log.WithName("RbacAssessmentReportOpenReportsClient").V(4),
 	}
 }

--- a/pkg/adapters/rbac/openreports/client.go
+++ b/pkg/adapters/rbac/openreports/client.go
@@ -58,6 +58,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.RbacAs
 	})
 }
 
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.OpenReportCleanup(ctx, p.k8sClient, "RbacAssessmentReport")
+}
+
 func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []string) rbac.ReportClient {
 	return &reportClient{
 		k8sClient: client,

--- a/pkg/adapters/rbac/polr_client.go
+++ b/pkg/adapters/rbac/polr_client.go
@@ -16,6 +16,7 @@ import (
 type ReportClient interface {
 	GenerateReport(ctx context.Context, report *v1alpha1.RbacAssessmentReport) error
 	DeleteReport(ctx context.Context, report *v1alpha1.RbacAssessmentReport) error
+	Cleanup(ctx context.Context) error
 }
 
 type reportClient struct {
@@ -60,6 +61,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.RbacAs
 
 		return nil
 	})
+}
+
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.WGPolrCleanup(ctx, p.k8sClient, "RbacAssessmentReport")
 }
 
 func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []string) ReportClient {

--- a/pkg/adapters/rbac/polr_client.go
+++ b/pkg/adapters/rbac/polr_client.go
@@ -1,12 +1,14 @@
 package rbac
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/apis/aquasecurity/v1alpha1"
@@ -22,6 +24,7 @@ type ReportClient interface {
 type reportClient struct {
 	k8sClient pr.Wgpolicyk8sV1alpha2Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.RbacAssessmentReport) error {
@@ -37,10 +40,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Rbac
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.PolicyReports(report.Namespace).Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.PolicyReports(report.Namespace).Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -73,5 +79,6 @@ func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []strin
 		mapper: &mapper{
 			shared.NewLabelMapper(applyLabels),
 		},
+		logger: ctrl.Log.WithName("RbacAssessmentReportClient").V(4),
 	}
 }

--- a/pkg/adapters/shared/operations.go
+++ b/pkg/adapters/shared/operations.go
@@ -1,0 +1,65 @@
+package shared
+
+import (
+	"context"
+	"fmt"
+
+	pr "github.com/fjogeleit/trivy-operator-polr-adapter/pkg/client/clientset/versioned/typed/policyreport/v1alpha2"
+	or "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+func WGPolrCleanup(ctx context.Context, client pr.Wgpolicyk8sV1alpha2Interface, source string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		list, err := client.PolicyReports(v1.NamespaceAll).List(ctx, v1.ListOptions{
+			LabelSelector: fmt.Sprintf("trivy-operator.source=%s", source),
+		})
+		if err != nil {
+			return err
+		}
+
+		namespaces := map[string]struct{}{}
+		for _, polr := range list.Items {
+			namespaces[polr.Namespace] = struct{}{}
+		}
+
+		for ns := range namespaces {
+			err = client.PolicyReports(ns).DeleteCollection(ctx, v1.DeleteOptions{}, v1.ListOptions{
+				LabelSelector: fmt.Sprintf("trivy-operator.source=%s", source),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to cleanup config audit reports: %w", err)
+			}
+		}
+
+		return nil
+	})
+}
+
+func OpenReportCleanup(ctx context.Context, client or.OpenreportsV1alpha1Interface, source string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		list, err := client.Reports(v1.NamespaceAll).List(ctx, v1.ListOptions{
+			LabelSelector: fmt.Sprintf("trivy-operator.source=%s", source),
+		})
+		if err != nil {
+			return err
+		}
+
+		namespaces := map[string]struct{}{}
+		for _, polr := range list.Items {
+			namespaces[polr.Namespace] = struct{}{}
+		}
+
+		for ns := range namespaces {
+			err = client.Reports(ns).DeleteCollection(ctx, v1.DeleteOptions{}, v1.ListOptions{
+				LabelSelector: fmt.Sprintf("trivy-operator.source=%s", source),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to cleanup config audit reports: %w", err)
+			}
+		}
+
+		return nil
+	})
+}

--- a/pkg/adapters/shared/operations.go
+++ b/pkg/adapters/shared/operations.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	pr "github.com/fjogeleit/trivy-operator-polr-adapter/pkg/client/clientset/versioned/typed/policyreport/v1alpha2"
 	or "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+
+	pr "github.com/fjogeleit/trivy-operator-polr-adapter/pkg/client/clientset/versioned/typed/policyreport/v1alpha2"
 )
 
 func WGPolrCleanup(ctx context.Context, client pr.Wgpolicyk8sV1alpha2Interface, source string) error {

--- a/pkg/adapters/vulnr/client.go
+++ b/pkg/adapters/vulnr/client.go
@@ -17,6 +17,7 @@ import (
 
 type Client interface {
 	StartWatching(ctx context.Context) error
+	Cleanup(ctx context.Context) error
 }
 
 type client struct {
@@ -46,6 +47,10 @@ func (e *client) StartWatching(ctx context.Context) error {
 			}
 		},
 	}))
+}
+
+func (e *client) Cleanup(ctx context.Context) error {
+	return e.polrClient.Cleanup(ctx)
 }
 
 func NewClient(mgr manager.Manager, controller controller.Controller, orClient ReportClient) Client {

--- a/pkg/adapters/vulnr/client.go
+++ b/pkg/adapters/vulnr/client.go
@@ -2,12 +2,12 @@ package vulnr
 
 import (
 	"context"
-	"log"
 
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -31,19 +31,19 @@ func (e *client) StartWatching(ctx context.Context) error {
 		CreateFunc: func(ctx context.Context, event event.TypedCreateEvent[*v1alpha1.VulnerabilityReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.polrClient.GenerateReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] VulnerabilityReport: Failed to process report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "VulnerabilityReport: failed to process report", "report", event.Object.Name)
 			}
 		},
 		UpdateFunc: func(ctx context.Context, event event.TypedUpdateEvent[*v1alpha1.VulnerabilityReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.polrClient.GenerateReport(ctx, event.ObjectNew)
 			if err != nil {
-				log.Printf("[ERROR] VulnerabilityReport: Failed to process report %s; %s", event.ObjectNew.Name, err)
+				ctrl.Log.Error(err, "VulnerabilityReport: failed to process report", "report", event.ObjectNew.Name)
 			}
 		},
 		DeleteFunc: func(ctx context.Context, event event.TypedDeleteEvent[*v1alpha1.VulnerabilityReport], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			err := e.polrClient.DeleteReport(ctx, event.Object)
 			if err != nil {
-				log.Printf("[ERROR] VulnerabilityReport: Failed to delete report %s; %s", event.Object.Name, err)
+				ctrl.Log.Error(err, "VulnerabilityReport: failed to delete report", "report", event.Object.Name)
 			}
 		},
 	}))

--- a/pkg/adapters/vulnr/openreports/client.go
+++ b/pkg/adapters/vulnr/openreports/client.go
@@ -58,6 +58,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Vulner
 	})
 }
 
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.OpenReportCleanup(ctx, p.k8sClient, "VulnerabilityReport")
+}
+
 func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []string) *reportClient {
 	return &reportClient{
 		k8sClient: client,

--- a/pkg/adapters/vulnr/openreports/client.go
+++ b/pkg/adapters/vulnr/openreports/client.go
@@ -1,13 +1,15 @@
 package openreports
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	or "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/vulnr"
@@ -17,6 +19,7 @@ import (
 type reportClient struct {
 	k8sClient or.OpenreportsV1alpha1Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.VulnerabilityReport) error {
@@ -32,10 +35,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Vuln
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting Report", "report", report.Name, "namespace", report.Namespace)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating Report", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.Reports(report.Namespace).Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating Report", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.Reports(report.Namespace).Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -68,5 +74,6 @@ func NewReportClient(client or.OpenreportsV1alpha1Interface, applyLabels []strin
 		mapper: &mapper{
 			LabelMapper: shared.NewLabelMapper(applyLabels),
 		},
+		logger: ctrl.Log.WithName("VulnerabilityReportOpenReportsClient").V(4),
 	}
 }

--- a/pkg/adapters/vulnr/polr_client.go
+++ b/pkg/adapters/vulnr/polr_client.go
@@ -1,12 +1,14 @@
 package vulnr
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/adapters/shared"
 	"github.com/fjogeleit/trivy-operator-polr-adapter/pkg/apis/aquasecurity/v1alpha1"
@@ -22,6 +24,7 @@ type ReportClient interface {
 type reportClient struct {
 	k8sClient pr.Wgpolicyk8sV1alpha2Interface
 	mapper    *mapper
+	logger    logr.Logger
 }
 
 func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.VulnerabilityReport) error {
@@ -37,10 +40,13 @@ func (p *reportClient) GenerateReport(ctx context.Context, report *v1alpha1.Vuln
 		if polr == nil {
 			return nil
 		} else if len(polr.Results) == 0 {
+			p.logger.Info("No results, deleting PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			err = p.DeleteReport(ctx, report)
 		} else if updated {
+			p.logger.Info("Updating PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.PolicyReports(report.Namespace).Update(ctx, polr, v1.UpdateOptions{})
 		} else {
+			p.logger.Info("Creating PolicyReport", "report", report.Name, "namespace", report.Namespace)
 			_, err = p.k8sClient.PolicyReports(report.Namespace).Create(ctx, polr, v1.CreateOptions{})
 		}
 
@@ -73,5 +79,6 @@ func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []strin
 		mapper: &mapper{
 			LabelMapper: shared.NewLabelMapper(applyLabels),
 		},
+		logger: ctrl.Log.WithName("VulnerabilityReportClient").V(4),
 	}
 }

--- a/pkg/adapters/vulnr/polr_client.go
+++ b/pkg/adapters/vulnr/polr_client.go
@@ -16,6 +16,7 @@ import (
 type ReportClient interface {
 	GenerateReport(ctx context.Context, report *v1alpha1.VulnerabilityReport) error
 	DeleteReport(ctx context.Context, report *v1alpha1.VulnerabilityReport) error
+	Cleanup(ctx context.Context) error
 }
 
 type reportClient struct {
@@ -60,6 +61,10 @@ func (p *reportClient) DeleteReport(ctx context.Context, report *v1alpha1.Vulner
 
 		return nil
 	})
+}
+
+func (p *reportClient) Cleanup(ctx context.Context) error {
+	return shared.WGPolrCleanup(ctx, p.k8sClient, "VulnerabilityReport")
 }
 
 func NewReportClient(client pr.Wgpolicyk8sV1alpha2Interface, applyLabels []string) ReportClient {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,10 +17,16 @@ type OpenReports struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
+// Logger configuration
+type Logger struct {
+	Verbosity int `mapstructure:"verbosity"`
+}
+
 // Config of the Tracee Adapter
 type Config struct {
 	Kubeconfig                    string       `mapstructure:"kubeconfig"`
 	UseWatchList                  bool         `mapstructure:"useWatchList"`
+	Logger                        Logger       `mapstructure:"logger"`
 	Server                        Server       `mapstructure:"server"`
 	OpenReport                    OpenReports  `mapstructure:"openReports"`
 	VulnerabilityReports          ReportConfig `mapstructure:"vulnerabilityReports"`

--- a/pkg/config/resolver.go
+++ b/pkg/config/resolver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	orv1alpha1 "github.com/openreports/reports-api/pkg/client/clientset/versioned/typed/openreports.io/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -58,6 +59,7 @@ type Resolver struct {
 	clusterInfraClient *clusterinfra.Client
 	kubeBenchClient    *kubebench.Client
 	mgr                manager.Manager
+	logger             logr.Logger
 }
 
 func (r *Resolver) CRDsClient() (dynamic.ResourceInterface, error) {


### PR DESCRIPTION
This pull request introduces improved logging, enhanced cleanup handling, and better configuration management for report adapters and the main command. The most important changes include replacing standard logging with structured logging via `controller-runtime`, adding cleanup steps before starting report watchers, and exposing logger verbosity as a configurable flag.

**Logging improvements:**
* Replaced all uses of the standard `log` package with structured logging using `controller-runtime`'s logger (`ctrl.Log`) throughout the codebase, ensuring consistent and configurable log output. This includes all report adapters and the main command logic. [[1]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349L6) [[2]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349R30-R35) [[3]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349L60-R147) [[4]](diffhunk://#diff-eb56f07f1ba9fad20913a92d6d132b3ea0ea24878fd35001702f44845718d9eaL5-R10) [[5]](diffhunk://#diff-eb56f07f1ba9fad20913a92d6d132b3ea0ea24878fd35001702f44845718d9eaL29-R50) [[6]](diffhunk://#diff-788e25a1ed01cc4aa2258b79446fa73947a312233e444d9313a87b292c6caf9cL5-R10) [[7]](diffhunk://#diff-788e25a1ed01cc4aa2258b79446fa73947a312233e444d9313a87b292c6caf9cL29-R50)

* Added more detailed log messages to the report client implementations (`pkg/adapters/auditr/polr_client.go`, `pkg/adapters/auditr/openreports/client.go`, `pkg/adapters/clusterinfra/openreports/client.go`) to indicate when reports are created, updated, deleted, or skipped due to no results. [[1]](diffhunk://#diff-d077d7165e89bfb7276fb1bade9734d477717f40c7ba95422c667f219cb949c2R43-R49) [[2]](diffhunk://#diff-0e46bd5b6a84297b6a3d4b3620a3290474e99f5df7face5ff7f447620f948b3eR38-R44) [[3]](diffhunk://#diff-d442e6cf26e9e806cf0d1898c12803d3633743b35313bb6aa27104071a9843edR38-R44)

**Configuration and CLI enhancements:**
* Introduced a new `--verbosity` (`-v`) command-line flag, allowing users to configure the logger's verbosity level. This flag is bound to the configuration and used to set up the logger at runtime. [[1]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349R257) [[2]](diffhunk://#diff-a05b455e3b2fb07016783280382977ac65ccd329647d2cf4a1c278ff037259ccL33-R35)

**Report lifecycle management:**
* Added a `Cleanup` method to all report client interfaces and implementations, and ensured that cleanup is called before starting each report watcher. This helps remove stale or orphaned reports before processing new events. [[1]](diffhunk://#diff-eb56f07f1ba9fad20913a92d6d132b3ea0ea24878fd35001702f44845718d9eaL29-R50) [[2]](diffhunk://#diff-d077d7165e89bfb7276fb1bade9734d477717f40c7ba95422c667f219cb949c2R21-R27) [[3]](diffhunk://#diff-d077d7165e89bfb7276fb1bade9734d477717f40c7ba95422c667f219cb949c2R72-R80) [[4]](diffhunk://#diff-0e46bd5b6a84297b6a3d4b3620a3290474e99f5df7face5ff7f447620f948b3eR67-R75) [[5]](diffhunk://#diff-788e25a1ed01cc4aa2258b79446fa73947a312233e444d9313a87b292c6caf9cL29-R50)

**Dependency updates:**
* Moved `github.com/go-logr/logr` from an indirect to a direct dependency in `go.mod` to support the new logging approach. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L26)

These changes collectively improve observability, configurability, and robustness of the application's report processing workflow.